### PR TITLE
Leave traces about 'content-encoding' before removing it

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -196,6 +196,9 @@ module.exports = function httpAdapter(config) {
         // add the unzipper to the body stream processing pipeline
           stream = stream.pipe(zlib.createUnzip());
 
+          // leave some traces about the 'content-encoding' before removing it
+          res.headers['axios-content-encoding'] = res.headers['content-encoding'];
+            
           // remove the content-encoding in order to not confuse downstream operations
           delete res.headers['content-encoding'];
           break;


### PR DESCRIPTION
Add 'axios-content-encoding' header before removing 'content-encoding' after decompression.
Because I want to make sure the data stream is transferred with GZIP in the unit test.
